### PR TITLE
Conversion to MaybeUninit + Warning Reduction 

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -186,7 +186,7 @@ impl fmt::Display for CastlingRights {
         let mut value = self.value();
         for s in ["Q", "K", "q", "k"].iter() {
             if value & 1 == 1 {
-                try!(f.write_str(s));
+                f.write_str(s)?;
             }
             value >>= 1;
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -230,7 +230,7 @@ impl<S, T> UciEngine for Engine<S, T>
         self.tt.clear();
     }
 
-    fn position(&mut self, fen: &str, moves: &mut Iterator<Item = &str>) {
+    fn position(&mut self, fen: &str, moves: &mut dyn Iterator<Item = &str>) {
         if let Ok(p) = S::SearchNode::from_history(fen, moves) {
             self.position = p;
         }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -24,7 +24,7 @@ use value::*;
 /// position has pending tactical threats, the static evaluation will
 /// be grossly incorrect. To implement your own static evaluator, you
 /// must define a type that implements the `Evaluator` trait.
-pub trait Evaluator: Clone + SetOption + Send + 'static {
+pub trait Evaluator: Clone + Copy + SetOption + Send + 'static {
     /// Creates a new instance bound to a given position.
     ///
     /// When a new evaluator is created it is bound to a particular

--- a/src/search_node.rs
+++ b/src/search_node.rs
@@ -47,7 +47,7 @@ pub trait SearchNode: Clone + SetOption + Send + 'static {
     /// moves that were played from that position. The move format is
     /// long algebraic notation. Examples: `e2e4`, `e7e5`, `e1g1`
     /// (white short castling), `e7e8q` (for promotion).
-    fn from_history(fen: &str, moves: &mut Iterator<Item = &str>) -> Result<Self, IllegalBoard>;
+    fn from_history(fen: &str, moves: &mut dyn Iterator<Item = &str>) -> Result<Self, IllegalBoard>;
 
     /// Returns an almost unique hash value for the position.
     ///

--- a/src/stock/deepening/aspiration.rs
+++ b/src/stock/deepening/aspiration.rs
@@ -104,7 +104,7 @@ impl<T: SearchExecutor> SearchExecutor for Aspiration<T> {
             value,
             done,
             ..
-        } = try!(self.searcher.try_recv_report());
+        } = self.searcher.try_recv_report()?;
         let mut report = SearchReport {
             search_id: self.params.search_id,
             searched_nodes: self.previously_searched_nodes + searched_nodes,

--- a/src/stock/deepening/mod.rs
+++ b/src/stock/deepening/mod.rs
@@ -122,7 +122,7 @@ impl<T: Search> SearchExecutor for Deepening<T> {
             data,
             done,
             ..
-        } = try!(self.multipv.try_recv_report());
+        } = self.multipv.try_recv_report()?;
         if value != VALUE_UNKNOWN {
             self.value = value;
         }

--- a/src/stock/deepening/multipv.rs
+++ b/src/stock/deepening/multipv.rs
@@ -115,7 +115,7 @@ impl<T: SearchExecutor> SearchExecutor for Multipv<T> {
                 value,
                 done,
                 ..
-            } = try!(self.searcher.try_recv_report());
+            } = self.searcher.try_recv_report()?;
             let mut report = SearchReport {
                 search_id: self.params.search_id,
                 searched_nodes: self.previously_searched_nodes + searched_nodes,

--- a/src/stock/simple_evaluator.rs
+++ b/src/stock/simple_evaluator.rs
@@ -10,7 +10,7 @@ use bitsets::*;
 
 /// A simple evaluator that adds a random number to the available
 /// material.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct SimpleEvaluator {
     material: Value,
 }

--- a/src/stock/std_move_generator.rs
+++ b/src/stock/std_move_generator.rs
@@ -1268,7 +1268,7 @@ mod tests {
 
     impl<E: Evaluator> StdMoveGenerator<E> {
         fn from_fen(fen: &str) -> Result<StdMoveGenerator<E>, IllegalBoard> {
-            StdMoveGenerator::from_board(try!(Board::from_fen(fen)))
+            StdMoveGenerator::from_board(Board::from_fen(fen)?)
         }
     }
     type P = StdMoveGenerator<SimpleEvaluator>;

--- a/src/stock/std_search_node.rs
+++ b/src/stock/std_search_node.rs
@@ -66,8 +66,8 @@ impl<T: Qsearch> SearchNode for StdSearchNode<T> {
 
     type QsearchResult = T::QsearchResult;
 
-    fn from_history(fen: &str, moves: &mut Iterator<Item = &str>) -> Result<Self, IllegalBoard> {
-        let mut p: StdSearchNode<T> = try!(StdSearchNode::from_fen(fen));
+    fn from_history(fen: &str, moves: &mut dyn Iterator<Item = &str>) -> Result<Self, IllegalBoard> {
+        let mut p: StdSearchNode<T> = StdSearchNode::from_fen(fen)?;
         let mut move_list = Vec::new();
         'played_moves: for played_move in moves {
             move_list.clear();
@@ -314,8 +314,8 @@ impl<T: Qsearch> SetOption for StdSearchNode<T> {
 impl<T: Qsearch> StdSearchNode<T> {
     /// Creates a new instance from Forsyth–Edwards Notation (FEN).
     pub fn from_fen(fen: &str) -> Result<StdSearchNode<T>, IllegalBoard> {
-        let (board, halfmove_clock, fullmove_number) = try!(parse_fen(fen));
-        let gen = try!(T::MoveGenerator::from_board(board));
+        let (board, halfmove_clock, fullmove_number) = parse_fen(fen)?;
+        let gen = T::MoveGenerator::from_board(board)?;
         Ok(StdSearchNode {
                zobrist: ZobristArrays::get(),
                halfmove_count: ((fullmove_number - 1) << 1) + gen.board().to_move as u16,

--- a/src/stock/std_ttable.rs
+++ b/src/stock/std_ttable.rs
@@ -440,7 +440,7 @@ mod tests {
             let b = Bucket::<Record<StdTtableEntry>>::new(p);
             assert_eq!(b.get_generation(0), 0);
             assert_eq!(b.get_generation(1), 0);
-            let mut record = b.get(0).as_mut().unwrap();
+            let record = b.get(0).as_mut().unwrap();
             let entry = StdTtableEntry::new(0, BOUND_NONE, 10);
             *record = Record {
                 key: (0, 0),
@@ -461,7 +461,7 @@ mod tests {
         unsafe {
             let p = libc::calloc(1, 64);
             let b = Bucket::<Record<StdTtableEntry>>::new(p);
-            let mut record = b.get(4).as_mut().unwrap();
+            let record = b.get(4).as_mut().unwrap();
             let entry = StdTtableEntry::new(0, BOUND_NONE, 10);
             *record = Record {
                 key: (0, 0),

--- a/src/stock/std_ttable.rs
+++ b/src/stock/std_ttable.rs
@@ -169,14 +169,14 @@ impl<T: TtableEntry> Ttable for StdTtable<T> {
         assert_eq!(mem::size_of::<c_void>(), 1);
         assert_eq!(BUCKET_SIZE, 64);
         assert!(mem::align_of::<T>() <= 4,
-                format!("too restrictive transposition table entry alignment: {} bytes",
-                        mem::align_of::<T>()));
+                "too restrictive transposition table entry alignment: {} bytes",
+                        mem::align_of::<T>());
         assert!(Bucket::<Record<T>>::len() >= 3,
-                format!("too big transposition table entry: {} bytes",
-                        mem::size_of::<T>()));
+                "too big transposition table entry: {} bytes",
+                        mem::size_of::<T>());
         assert!(Bucket::<Record<T>>::len() <= 6,
-                format!("too small transposition table entry: {} bytes",
-                        mem::size_of::<T>()));
+                "too small transposition table entry: {} bytes",
+                        mem::size_of::<T>());
 
         let size_mb = size_mb.unwrap_or(16);
         let bucket_count = {
@@ -210,7 +210,7 @@ impl<T: TtableEntry> Ttable for StdTtable<T> {
             // Increment the generation number (with wrapping).
             self.generation
                 .set(match self.generation.get() {
-                         n @ 1...30 => n + 1,
+                         n @ 1..=30 => n + 1,
                          31 => 1,
                          _ => unreachable!(),
                      });

--- a/src/utils/board_geometry.rs
+++ b/src/utils/board_geometry.rs
@@ -225,8 +225,8 @@ impl BoardGeometry {
     /// calls will return a reference to the same object. This is done
     /// in a thread-safe manner.
     pub fn get() -> &'static BoardGeometry {
-        use std::sync::{Once, ONCE_INIT};
-        static INIT_GEOMETRY: Once = ONCE_INIT;
+        use std::sync::Once;
+        static INIT_GEOMETRY: Once = Once::new();
         static mut GEOMETRY: Option<BoardGeometry> = None;
         unsafe {
             INIT_GEOMETRY.call_once(|| { GEOMETRY = Some(BoardGeometry::new()); });

--- a/src/utils/notation.rs
+++ b/src/utils/notation.rs
@@ -50,12 +50,12 @@ use ranks::*;
 /// ## Example:
 /// The starting position: `rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w QKqk - 0 1`
 pub fn parse_fen(s: &str) -> Result<(Board, u8, u16), IllegalBoard> {
-    let fileds: Vec<_> = s.split_whitespace().collect();
-    if fileds.len() == 6 {
-        let pieces = try!(parse_fen_piece_placement(fileds[0]));
-        let to_move = try!(parse_fen_active_color(fileds[1]));
-        let castling_rights = try!(parse_fen_castling_rights(fileds[2]));
-        let enpassant_file = if let Some(x) = try!(parse_fen_enpassant_square(fileds[3])) {
+    let fields: Vec<_> = s.split_whitespace().collect();
+    if fields.len() == 6 {
+        let pieces = parse_fen_piece_placement(fields[0])?;
+        let to_move = parse_fen_active_color(fields[1])?;
+        let castling_rights = parse_fen_castling_rights(fields[2])?;
+        let enpassant_file = if let Some(x) = parse_fen_enpassant_square(fields[3])? {
             match to_move {
                 WHITE if Board::rank(x) == RANK_6 => Board::file(x),
                 BLACK if Board::rank(x) == RANK_3 => Board::file(x),
@@ -64,9 +64,9 @@ pub fn parse_fen(s: &str) -> Result<(Board, u8, u16), IllegalBoard> {
         } else {
             8
         };
-        let halfmove_clock = try!(fileds[4].parse::<u8>().map_err(|_| IllegalBoard));
-        let fullmove_number = try!(fileds[5].parse::<u16>().map_err(|_| IllegalBoard));
-        if let 1...9000 = fullmove_number {
+        let halfmove_clock = fields[4].parse::<u8>().map_err(|_| IllegalBoard)?;
+        let fullmove_number = fields[5].parse::<u16>().map_err(|_| IllegalBoard)?;
+        if let 1..=9000 = fullmove_number {
             return Ok((Board {
                            occupied: pieces.color[WHITE] | pieces.color[BLACK],
                            pieces: pieces,
@@ -131,7 +131,7 @@ fn parse_fen_piece_placement(s: &str) -> Result<PiecesPlacement, IllegalBoard> {
             'b' => Token::Piece(BLACK, BISHOP),
             'n' => Token::Piece(BLACK, KNIGHT),
             'p' => Token::Piece(BLACK, PAWN),
-            n @ '1'...'8' => Token::EmptySquares(n.to_digit(9).unwrap()),
+            n @ '1'..='8' => Token::EmptySquares(n.to_digit(9).unwrap()),
             '/' => Token::Separator,
             _ => return Err(IllegalBoard),
         };

--- a/src/utils/zobrist_arrays.rs
+++ b/src/utils/zobrist_arrays.rs
@@ -84,8 +84,8 @@ impl ZobristArrays {
     /// calls will return a reference to the same object. This is done
     /// in a thread-safe manner.
     pub fn get() -> &'static ZobristArrays {
-        use std::sync::{Once, ONCE_INIT};
-        static INIT_ARRAYS: Once = ONCE_INIT;
+        use std::sync::Once;
+        static INIT_ARRAYS: Once = Once::new();
         static mut ARRAYS: Option<ZobristArrays> = None;
         unsafe {
             INIT_ARRAYS.call_once(|| { ARRAYS = Some(ZobristArrays::new()); });


### PR DESCRIPTION
This resolves #2, along with replacing all other uses of `uninitialized` with an appropriate `MaybeUninit` and converting some other code considered deprecated as of Rust 1.39.